### PR TITLE
Fixed case mismatch for linux packaging

### DIFF
--- a/Source/ArticyEditor/Private/ArticyArchiveReader.cpp
+++ b/Source/ArticyEditor/Private/ArticyArchiveReader.cpp
@@ -6,7 +6,7 @@
 #include "ArticyEditorModule.h"
 #include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
-#include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformFilemanager.h"
 
 bool UArticyArchiveReader::OpenArchive(const FString& InArchiveFileName)
 {

--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -19,7 +19,7 @@
 #include "StringTableGenerator.h"
 #include "BuildToolParser/BuildToolParser.h"
 #include "Serialization/JsonSerializer.h"
-#include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformFilemanager.h"
 #include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
 #include "Factories/SoundFactory.h"


### PR DESCRIPTION
Fixed case mismatch in ArticyArchiveReader and ArticyImportData for Platform file manager.