### PR TITLE
Linker issue missing ArticyRuntime in Editor module

### DIFF
--- a/Source/ArticyEditor/ArticyEditor.Build.cs
+++ b/Source/ArticyEditor/ArticyEditor.Build.cs
@@ -61,6 +61,7 @@ public class ArticyEditor : ModuleRules
 				"GraphEditor",
 				"AudioEditor",
 				"ApplicationCore",
+				"ArticyRuntime",
 #if UE_5_0_OR_LATER
 				"ToolMenus",
 #endif


### PR DESCRIPTION
Editor module will not link because of missing dependency on Articy Runtime.

- Linker issue, missing ArticyRuntime private dependency module. 