### PR TITLE
Address possible errors/warnings in Unreal 5

### DIFF
--- a/Source/ArticyEditor/Public/ArticyImportData.h
+++ b/Source/ArticyEditor/Public/ArticyImportData.h
@@ -250,7 +250,7 @@ public:
 	UPROPERTY(VisibleAnywhere, Category="Language")
 	FString LanguageName;
 	UPROPERTY(VisibleAnywhere, Category="Language")
-	bool IsVoiceOver;
+	bool IsVoiceOver = false;
 
 	void ImportFromJson(const TSharedPtr<FJsonObject>& JsonRoot);
 };

--- a/Source/ArticyRuntime/Public/ArticyType.h
+++ b/Source/ArticyRuntime/Public/ArticyType.h
@@ -22,7 +22,7 @@ public:
 	FString TechnicalName;
 
 	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Articy")
-	int Value;
+	int Value = 0;
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
From Avalanche Software working on next project in Unreal 5.4:

"LogAutomationTest: Error: LogClass: IntProperty FArticyEnumValueInfo::Value is not initialized properly. Module:ArticyRuntime [File:Public/ArticyType.h](file://public/ArticyType.h)"
"LogAutomationTest: Error: LogClass: BoolProperty FArticyLanguageDef::IsVoiceOver is not initialized properly. Module:ArticyEditor [File:Public/ArticyImportData.h](file://public/ArticyImportData.h)"