### PR TITLE
Fix LocalizeString func in ArticyLocalizerSystem.h returning BackupText before checking for ResolveTextExtension

### DIFF
--- a/Source/ArticyRuntime/Public/ArticyLocalizerSystem.h
+++ b/Source/ArticyRuntime/Public/ArticyLocalizerSystem.h
@@ -99,16 +99,17 @@ public:
 			return FText(SourceString);
 		}
 
-		if (BackupText)
-		{
-			return *BackupText;
-		}
-
 		// By default, return via the key
 		if (ResolveTextExtension)
 		{
 			return ResolveText(Outer, &Key);
 		}
+
+		if (BackupText)
+		{
+			return *BackupText;
+		}
+		
 		return Key;
 	}
 


### PR DESCRIPTION
The game displayed BackupText ("...") from `ArticyObjectWithMenuText.h` instead of the actual menu texts from Articy. The blueprint check against an empty string always returned false, making the menu texts unavailable, which was also caused by the BackupText being returned every single time, therefore menu text was always "..." as set in `ArticyObjectWithMenuText.h`.

I attempted to fix the issue by not sending the BackupText in `ArticyObjectWithMenuText.h`, which temporarily resolved the problem. However, when diving deeper into the code I found that the root cause was in `ArticyLocalizerSystem.h` (or so I think at least).

The issue was that the code always checked for the BackupText reference before attempting to resolve the text being sent from Articy. This caused the game to default to the BackupText even when valid menu texts were available.

The fix was to change the order of code inside `ArticyLocalizerSystem.h` to correctly prioritize resolving the menu texts from Articy before falling back to the BackupText. With this, the menu texts are now correctly being displayed in the game, and blueprint checks against the menu texts function as intended. 