### PR TITLE
Fix StartOn validity check

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
+++ b/Source/ArticyRuntime/Private/ArticyFlowPlayer.cpp
@@ -539,9 +539,9 @@ void UArticyFlowPlayer::UpdateAvailableBranchesInternal(bool Startup)
  */
 void UArticyFlowPlayer::SetCursorToStartNode()
 {
-    // This ensure Flowplayer construction whithout Throwing
+    // This ensure Flowplayer construction without throwing
     // error message when setup in Actor construction with C++
-    if (StartOn.NoneSet)
+    if (StartOn.GetId().IsNull())
     {
         return;
     }


### PR DESCRIPTION
Hello!

When UArticyFlowPlayer added as a component to an actor and it has no StartOn object set, it writes the following warning to Output log:
```
LogArticyRuntime: Warning: Could not set cursor in flow player of actor BP_DialoguePlayer_C_0: invalid node
```

It seems that the check in SetCursorToStartNode doesn't work as intended. This pull request improves the check so that we don't get false positive warnings from the plugin.