### PR TITLE
Bugfix/interface includes

### DIFF
--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -1147,7 +1147,7 @@ void UArticyImportData::ImportAudioAssets(const FString& BaseContentDir)
 	// Metadata helpers
 	auto GetMetaValue = [](UPackage* Package, UObject* Object, const TCHAR* Key) -> FString
 		{
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
 			if (!Package) return FString();
 			return Package->GetMetaData().GetValue(Object, Key);
 #else
@@ -1159,18 +1159,16 @@ void UArticyImportData::ImportAudioAssets(const FString& BaseContentDir)
 
 	auto SetMetaValue = [](UPackage* Package, UObject* Object, const TCHAR* Key, const FString& Value)
 		{
-#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3)
+#if ENGINE_MAJOR_VERSION > 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 6)
 			if (!Package) return;
 			Package->GetMetaData().SetValue(Object, Key, *Value);
 #else
 			if (!Package) return;
 			UMetaData* MetaData = Package->GetMetaData();
-			if (!MetaData)
+			if (MetaData)
 			{
-				MetaData = NewObject<UMetaData>(Package, NAME_None, RF_Standalone);
-				Package->SetMetaData(MetaData);
+				MetaData->SetValue(Object, Key, *Value);
 			}
-			MetaData->SetValue(Object, Key, *Value);
 #endif
 		};
 

--- a/Source/ArticyEditor/Private/BuildToolParser/BuildToolParser.cpp
+++ b/Source/ArticyEditor/Private/BuildToolParser/BuildToolParser.cpp
@@ -4,6 +4,7 @@
 
 #include "BuildToolParser.h"
 #include "ArticyEditorModule.h"
+#include "Internationalization/Regex.h"
 
 /**
  * @brief Constructs a BuildToolParser object and sets the file path.

--- a/Source/ArticyEditor/Private/PredefinedTypes.cpp
+++ b/Source/ArticyEditor/Private/PredefinedTypes.cpp
@@ -7,6 +7,7 @@
 #include "ArticyObject.h"
 #include "ArticyBuiltinTypes.h"
 #include "ArticyScriptFragment.h"
+#include "Internationalization/Regex.h"
 
 #define STRINGIFY(x) #x
 

--- a/Source/ArticyEditor/Private/Slate/AssetPicker/SArticyObjectAssetPicker.cpp
+++ b/Source/ArticyEditor/Private/Slate/AssetPicker/SArticyObjectAssetPicker.cpp
@@ -19,6 +19,7 @@
 #include "Framework/Application/SlateApplication.h"
 #include "ArticyEditorModule.h"
 #include "HAL/PlatformApplicationMisc.h"
+#include "Async/Async.h"
 
 #define LOCTEXT_NAMESPACE "ArticyObjectAssetPicker"
 

--- a/Source/ArticyEditor/Public/ArticyImportData.h
+++ b/Source/ArticyEditor/Public/ArticyImportData.h
@@ -11,6 +11,8 @@
 #include "ArticyArchiveReader.h"
 #include "StringTableGenerator.h"
 #include "Serialization/Csv/CsvParser.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
 #include "ArticyImportData.generated.h"
 
 class UArticyImportData;

--- a/Source/ArticyEditor/Public/ArticyImporterHelpers.h
+++ b/Source/ArticyEditor/Public/ArticyImporterHelpers.h
@@ -11,6 +11,7 @@
 #endif
 #include "UObject/Package.h"
 #include "UObject/ConstructorHelpers.h"
+#include "Engine/Engine.h"
 #include "Interfaces/ArticyObjectWithPosition.h"
 #include "Interfaces/ArticyNode.h"
 

--- a/Source/ArticyEditor/Public/Slate/AssetPicker/SArticyObjectAssetPicker.h
+++ b/Source/ArticyEditor/Public/Slate/AssetPicker/SArticyObjectAssetPicker.h
@@ -6,6 +6,7 @@
 
 #include "CoreMinimal.h"
 #include "ContentBrowserDelegates.h"
+#include "AssetRegistry/AssetData.h"
 #include "ArticyObject.h"
 #include <Widgets/SCompoundWidget.h>
 #include <Widgets/Views/STableViewBase.h>

--- a/Source/ArticyRuntime/Public/ArticyBranchSorters.h
+++ b/Source/ArticyRuntime/Public/ArticyBranchSorters.h
@@ -94,8 +94,8 @@ namespace ArticyBranchSorters
         {
             if (AInputPin != nullptr && BInputPin != nullptr)
             {
-                UArticyObject* AOwner = UArticyObject::FindAsset(AInputPin->Owner);
-                UArticyObject* BOwner = UArticyObject::FindAsset(BInputPin->Owner);
+                UArticyObject* AOwner = AInputPin->Owner.GetObject<UArticyObject>(AInputPin);
+                UArticyObject* BOwner = BInputPin->Owner.GetObject<UArticyObject>(BInputPin);
                 
                 const IArticyObjectWithPosition* AOwnerPos = Cast<IArticyObjectWithPosition>(AOwner);
                 const IArticyObjectWithPosition* BOwnerPos = Cast<IArticyObjectWithPosition>(BOwner);

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyConditionProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyConditionProvider.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "UObject/Interface.h"
 #include "ArticyConditionProvider.generated.h"
 
 UINTERFACE(meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyFlowObject.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyFlowObject.h
@@ -7,6 +7,7 @@
 #include "ArticyPausableType.h"
 #include "ArticyReflectable.h"
 
+#include "UObject/Interface.h"
 #include "ArticyFlowObject.generated.h"
 
 struct FArticyBranch;

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyInputPinsProvider.h
@@ -6,6 +6,7 @@
 
 #include "ArticyPins.h"
 #include "ArticyFlowObject.h"
+#include "UObject/Interface.h"
 #include "ArticyInputPinsProvider.generated.h"
 
 /**

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyInstructionProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyInstructionProvider.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "UObject/Interface.h"
 #include "ArticyInstructionProvider.generated.h"
 
 UINTERFACE(meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithAttachments.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithAttachments.h
@@ -7,6 +7,7 @@
 #include "ArticyBaseTypes.h"
 #include "ArticyPrimitive.h"
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithAttachments.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithColor.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithColor.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithColor.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithDisplayName.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithDisplayName.h
@@ -7,6 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "UObject/TextProperty.h"
 #include "ArticyBaseTypes.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithDisplayName.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithExternalId.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithExternalId.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithExternalId.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithMenuText.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithMenuText.h
@@ -7,6 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyObjectWithText.h"
 #include "ArticyTextExtension.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithMenuText.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPosition.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPosition.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithPosition.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPreviewImage.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithPreviewImage.h
@@ -6,6 +6,7 @@
 
 #include "ArticyObjectWith_Base.h"
 #include "ArticyBuiltinTypes.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithPreviewImage.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithShortId.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithShortId.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithShortId.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSize.h
@@ -6,6 +6,7 @@
 
 #include "ArticyObjectWith_Base.h"
 #include "ArticyBaseTypes.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithSize.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSpeaker.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithSpeaker.h
@@ -7,6 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyBaseTypes.h"
 #include "ArticyObject.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithSpeaker.generated.h"
 
 struct FArticyId;

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithStageDirections.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithStageDirections.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithStageDirections.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTarget.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTarget.h
@@ -7,6 +7,7 @@
 #include "ArticyObjectWith_Base.h"
 #include "ArticyPrimitive.h"
 #include "ArticyBaseTypes.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithTarget.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
@@ -11,6 +11,7 @@
 #include "ArticyAsset.h"
 #include "ArticyDatabase.h"
 #include "ArticyTextExtension.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithText.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTransform.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithTransform.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithTransform.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithVertices.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithVertices.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithVertices.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithZIndex.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithZIndex.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ArticyObjectWith_Base.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWithZIndex.generated.h"
 
 UINTERFACE(MinimalAPI, BlueprintType, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWith_Base.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWith_Base.h
@@ -6,6 +6,7 @@
 
 #include "ArticyReflectable.h"
 #include "ArticyHelpers.h"
+#include "UObject/Interface.h"
 #include "ArticyObjectWith_Base.generated.h"
 
 UINTERFACE(MinimalAPI, meta=(CannotImplementInterfaceInBlueprint))

--- a/Source/ArticyRuntime/Public/Interfaces/ArticyOutputPinsProvider.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyOutputPinsProvider.h
@@ -6,6 +6,7 @@
 
 #include "ArticyPins.h"
 #include "ArticyFlowObject.h"
+#include "UObject/Interface.h"
 #include "ArticyOutputPinsProvider.generated.h"
 
 /**


### PR DESCRIPTION
The were build issues with the latest release and I made these changes to get a deterministic include order for headers, and also deal with some engine version specific issues.

It's possible that some includes may be redundant.

Some notes:
- UPackage::GetMetaData() lazily creates the metadata and never returns null in 5.5
- FindAsset is editor-only