### PR TITLE
feat: restart notice on import after upgrade / fix: dangling reference from `RenameGeneratedAssets`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -11,6 +11,7 @@
     - Object deduplication across packages
     - Sort flow branches by target position
     - Per-asset package eviction
+    - Editor-restart reminder on importer upgrade
 - Fixes:
     - Fix occasional CTD in object asset picker
     - Fix stale import data on reimport
@@ -18,6 +19,8 @@
     - Fix default package handling
     - Fix include order and missing includes
     - Handle CSV import dialog
+- Known Issues:
+    - Possible crash on Play after upgrading
     
 ## Unreal Importer 1.5.0 Changelog :
 

--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ For greater control over your imports, use the Articy X Importer Menu. It can be
 - **Import Changes**: This option will only regenerate code and compile it if necessary, but will always regenerate assets. This is generally faster than a full reimport and is the same as clicking on 'Import' on the prompt Unreal shows you when you've exported.
 - **Regenerate Assets**: This option will only regenerate the articy assets based on the current import data asset and compiled code.
 
+> NOTE: After **upgrading the importer to a new version**, restart the Unreal editor before the first **Play** following an import. Importing recompiles and hot-reloads the project's generated code in-session, and after a version change that hot reload can crash on Play. Restarting loads the regenerated code cleanly. The importer will show a reminder when it detects an upgrade.
+
 # Selective Import
 
 For larger projects, exporting the entire articy:draft X project every time a single line of dialogue changes is slow. The importer supports selective import, where articy:draft X ships only the packages you changed in the `.articyue` file. The Unreal plugin then updates just those packages and leaves the rest of your imported data untouched.

--- a/Source/ArticyEditor/Private/ArticyEditorFunctionLibrary.cpp
+++ b/Source/ArticyEditor/Private/ArticyEditorFunctionLibrary.cpp
@@ -14,8 +14,48 @@
 #include "Misc/MessageDialog.h"
 #include "Misc/Paths.h"
 #include "Interfaces/IPluginManager.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Framework/Application/SlateApplication.h"
+#include "Widgets/Notifications/SNotificationList.h"
 
 #define LOCTEXT_NAMESPACE "ArticyEditorFunctionLibrary"
+
+namespace
+{
+	/** Notifies the user to restart the editor before Play after an importer upgrade. */
+	void ShowPluginUpgradeRestartNotice()
+	{
+		// Skip headless imports (commandlets).
+		if (IsRunningCommandlet() || GIsRunningUnattendedScript || !FSlateApplication::IsInitialized())
+		{
+			return;
+		}
+
+		FNotificationInfo Info(LOCTEXT("PluginUpgradeRestart",
+			"The articy:draft X importer was updated since the last import.\n"
+			"Please restart the Unreal editor before entering Play to avoid a known hot-reload crash."));
+		Info.bFireAndForget = false;
+		Info.bUseLargeFont = false;
+		Info.bUseThrobber = false;
+		Info.FadeOutDuration = 0.5f;
+
+		// Captured so the Dismiss button can fade the item out.
+		const TSharedRef<TSharedPtr<SNotificationItem>> ItemHolder = MakeShared<TSharedPtr<SNotificationItem>>();
+		Info.ButtonDetails.Add(FNotificationButtonInfo(
+			LOCTEXT("PluginUpgradeRestartDismiss", "Dismiss"),
+			FText::GetEmpty(),
+			FSimpleDelegate::CreateLambda([ItemHolder]()
+			{
+				if (ItemHolder->IsValid())
+				{
+					(*ItemHolder)->ExpireAndFadeout();
+				}
+			}),
+			SNotificationItem::CS_None));
+
+		*ItemHolder = FSlateNotificationManager::Get().AddNotification(Info);
+	}
+}
 
 FString FArticyEditorFunctionLibrary::ForcedArticyDirectory;
 
@@ -139,6 +179,8 @@ int32 FArticyEditorFunctionLibrary::ReimportChanges(UArticyImportData* ImportDat
 		UE_LOG(LogArticyEditor, Log,
 			TEXT("Articy importer plugin upgraded (was '%s', now '%s'); forcing full reimport."),
 			*ImportData->LastImporterPluginVersion, *CurrentPluginVersion);
+		// The reimport below hot-reloads regenerated code; advise a restart before Play.
+		ShowPluginUpgradeRestartNotice();
 		return ForceCompleteReimport(ImportData);
 	}
 

--- a/Source/ArticyEditor/Private/CodeGeneration/CodeGenerator.cpp
+++ b/Source/ArticyEditor/Private/CodeGeneration/CodeGenerator.cpp
@@ -499,6 +499,9 @@ bool CodeGenerator::RenameGeneratedAssets(const FArticyPackageDefs& PackageDefs)
 	TArray<FAssetData> OutAssets;
 	AssetRegistry.Get().GetAssetsByPath(FName(*ArticyHelpers::GetArticyGeneratedFolder()), OutAssets, true, false);
 
+	// GetPackages() returns by value; bind to a local so MatchingDef doesn't dangle.
+	const TArray<FArticyPackageDef> AllPackageDefs = PackageDefs.GetPackages();
+
 	for (const FAssetData& Data : OutAssets)
 	{
 		if (Data.IsValid())
@@ -520,7 +523,7 @@ bool CodeGenerator::RenameGeneratedAssets(const FArticyPackageDefs& PackageDefs)
 
 			// Match by PackageId; fall back to Name for legacy assets.
 			const FArticyPackageDef* MatchingDef = nullptr;
-			for (const FArticyPackageDef& PackageDef : PackageDefs.GetPackages())
+			for (const FArticyPackageDef& PackageDef : AllPackageDefs)
 			{
 				if (!PackageAsset->PackageId.IsNull())
 				{


### PR DESCRIPTION
Fixes an intermittent dangling reference in `RenameGeneratedAssets`, and adds the "restart after upgrading" guidance.