### PR TITLE
fix: VO asset retrieval from wrong lookup table

### DIFF
--- a/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
+++ b/Source/ArticyRuntime/Public/Interfaces/ArticyObjectWithText.h
@@ -55,15 +55,10 @@ public:
 		const FText MissingEntry = FText::FromString("<MISSING STRING TABLE ENTRY>");
 		FArticyId AssetId;
 
-		// Look up entry in specified string table
-		TOptional<FString> TableName = FTextInspector::GetNamespace(Key);
-		if (!TableName.IsSet())
-		{
-			TableName = TEXT("ARTICY");
-		}
+		const FName TableName = TEXT("ARTICY");
 
 		// Find the table
-		FStringTableConstPtr TablePtr = FStringTableRegistry::Get().FindStringTable(FName(TableName.GetValue()));
+		FStringTableConstPtr TablePtr = FStringTableRegistry::Get().FindStringTable(TableName);
 		if (!TablePtr.IsValid())
 		{
 			return nullptr;


### PR DESCRIPTION
Previously, we dynamically generated string table names, but we are now using a single hard-coded table name.

The code was looking for the assets in the wrong table based on the namespace, which is no longer relevant.

As this impacts only data retrieval, I'm not anticipating any side effects.