### PR TITLE
Fix seen/unseen regression

### DIFF
--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -1446,14 +1446,14 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 	const FRegexPattern unseenPattern(TEXT("\\bunseen\\b"));
 	const FRegexPattern seenCounterPattern(TEXT("\\bseenCounter\\b"));
 
-	//replace a shorthand keyword with a getSeenCounter() call, keeping any optional
-	//(balanced) argument so seen("Obj") hits the name/id overload; Prefix/Suffix wrap it
+	// replace a shorthand keyword with a getSeenCounter() call, keeping any optional
+	// (balanced) argument so seen("Obj") hits the name/id overload; Prefix/Suffix wrap it
 	auto replaceSeenKeyword = [&literalStringPattern](FString& Line, const FRegexPattern& Pattern,
 		const FString& Prefix, const FString& Suffix)
 	{
 		for (int32 searchStart = 0; searchStart <= Line.Len(); )
 		{
-			//re-scan from scratch after each edit, since replacements shift the string
+			// re-scan from scratch after each edit, since replacements shift the string
 			FRegexMatcher matcher(Pattern, Line);
 			int32 kwStart = INDEX_NONE, kwEnd = INDEX_NONE;
 			while (matcher.FindNext())
@@ -1468,7 +1468,7 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 			if (kwStart == INDEX_NONE)
 				break;
 
-			//don't touch the keyword if it appears inside a literal string (e.g. print text)
+			// don't touch the keyword if it appears inside a literal string (e.g. print text)
 			bool inLiteral = false;
 			FRegexMatcher literals(literalStringPattern, Line);
 			while (literals.FindNext())
@@ -1485,8 +1485,8 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 				continue;
 			}
 
-			//capture an optional balanced (...) argument list following the keyword,
-			//ignoring parens that live inside a string literal
+			// capture an optional balanced (...) argument list following the keyword,
+			// ignoring parens that live inside a string literal
 			int32 cursor = kwEnd;
 			while (cursor < Line.Len() && FChar::IsWhitespace(Line[cursor]))
 				++cursor;
@@ -1504,7 +1504,7 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 					if (inString)
 					{
 						if (c == TEXT('\\'))
-							++i; //skip escaped char
+							++i; // skip escaped char
 						else if (c == TEXT('"'))
 							inString = false;
 					}
@@ -1514,11 +1514,11 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 						++depth;
 					else if (c == TEXT(')') && --depth == 0)
 					{
-						++i; //move past the matching ')'
+						++i; // move past the matching ')'
 						break;
 					}
 				}
-				args = Line.Mid(cursor + 1, (i - 1) - (cursor + 1)); //contents inside the parens
+				args = Line.Mid(cursor + 1, (i - 1) - (cursor + 1)); // contents inside the parens
 				replaceEnd = i;
 			}
 
@@ -1640,8 +1640,8 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 				} // !inLiteral
 			} // GV matching
 
-			//replace "seen"/"unseen"/"seenCounter" with getSeenCounter() calls
-			//(order is safe: none of the patterns match inside the others' output)
+			// replace "seen"/"unseen"/"seenCounter" with getSeenCounter() calls
+			// (order is safe: none of the patterns match inside the others' output)
 			replaceSeenKeyword(line, seenPattern, TEXT("("), TEXT(" > 0)"));
 			replaceSeenKeyword(line, unseenPattern, TEXT("("), TEXT(" == 0)"));
 			replaceSeenKeyword(line, seenCounterPattern, TEXT(""), TEXT(""));

--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -1446,6 +1446,88 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 	const FRegexPattern unseenPattern(TEXT("\\bunseen\\b"));
 	const FRegexPattern seenCounterPattern(TEXT("\\bseenCounter\\b"));
 
+	//replace a shorthand keyword with a getSeenCounter() call, keeping any optional
+	//(balanced) argument so seen("Obj") hits the name/id overload; Prefix/Suffix wrap it
+	auto replaceSeenKeyword = [&literalStringPattern](FString& Line, const FRegexPattern& Pattern,
+		const FString& Prefix, const FString& Suffix)
+	{
+		for (int32 searchStart = 0; searchStart <= Line.Len(); )
+		{
+			//re-scan from scratch after each edit, since replacements shift the string
+			FRegexMatcher matcher(Pattern, Line);
+			int32 kwStart = INDEX_NONE, kwEnd = INDEX_NONE;
+			while (matcher.FindNext())
+			{
+				if (matcher.GetMatchBeginning() >= searchStart)
+				{
+					kwStart = matcher.GetMatchBeginning();
+					kwEnd = matcher.GetMatchEnding();
+					break;
+				}
+			}
+			if (kwStart == INDEX_NONE)
+				break;
+
+			//don't touch the keyword if it appears inside a literal string (e.g. print text)
+			bool inLiteral = false;
+			FRegexMatcher literals(literalStringPattern, Line);
+			while (literals.FindNext())
+			{
+				if (kwStart >= literals.GetMatchBeginning() && kwEnd <= literals.GetMatchEnding())
+				{
+					inLiteral = true;
+					break;
+				}
+			}
+			if (inLiteral)
+			{
+				searchStart = kwEnd;
+				continue;
+			}
+
+			//capture an optional balanced (...) argument list following the keyword,
+			//ignoring parens that live inside a string literal
+			int32 cursor = kwEnd;
+			while (cursor < Line.Len() && FChar::IsWhitespace(Line[cursor]))
+				++cursor;
+
+			FString args;
+			int32 replaceEnd = kwEnd;
+			if (cursor < Line.Len() && Line[cursor] == TEXT('('))
+			{
+				int32 depth = 0;
+				bool inString = false;
+				int32 i = cursor;
+				for (; i < Line.Len(); ++i)
+				{
+					const TCHAR c = Line[i];
+					if (inString)
+					{
+						if (c == TEXT('\\'))
+							++i; //skip escaped char
+						else if (c == TEXT('"'))
+							inString = false;
+					}
+					else if (c == TEXT('"'))
+						inString = true;
+					else if (c == TEXT('('))
+						++depth;
+					else if (c == TEXT(')') && --depth == 0)
+					{
+						++i; //move past the matching ')'
+						break;
+					}
+				}
+				args = Line.Mid(cursor + 1, (i - 1) - (cursor + 1)); //contents inside the parens
+				replaceEnd = i;
+			}
+
+			const FString replacement = Prefix + TEXT("getSeenCounter(") + args + TEXT(")") + Suffix;
+			Line = Line.Left(kwStart) + replacement + Line.Mid(replaceEnd);
+			searchStart = kwStart + replacement.Len();
+		}
+	};
+
 	bool bCreateBlueprintableUserMethods = UArticyPluginSettings::Get()->bCreateBlueprintTypeForScriptMethods;
 
 	FString string = Fragment; //Fragment.Replace(TEXT("\n"), TEXT(""));
@@ -1558,39 +1640,11 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 				} // !inLiteral
 			} // GV matching
 
-			// replace "seen" and "unseen" with corresponding expressions
-			FRegexMatcher seenMatcher(seenPattern, line);
-			FRegexMatcher unseenMatcher(unseenPattern, line);
-
-			while (seenMatcher.FindNext())
-			{
-				auto start = seenMatcher.GetMatchBeginning() + offset;
-				auto end = seenMatcher.GetMatchEnding() + offset;
-				line = line.Left(start) + TEXT("seenCounter > 0") + line.Mid(end);
-				offset += strlen("seenCounter > 0") - (end - start);
-			}
-
-			offset = 0; // reset offset for unseen replacement
-
-			while (unseenMatcher.FindNext())
-			{
-				auto start = unseenMatcher.GetMatchBeginning() + offset;
-				auto end = unseenMatcher.GetMatchEnding() + offset;
-				line = line.Left(start) + TEXT("seenCounter == 0") + line.Mid(end);
-				offset += strlen("seenCounter == 0") - (end - start);
-			}
-
-			FRegexMatcher seenCounterMatcher(seenCounterPattern, line);
-
-			offset = 0; // reset offset for seen counter replacement
-
-			while (seenCounterMatcher.FindNext())
-			{
-				auto start = seenCounterMatcher.GetMatchBeginning() + offset;
-				auto end = seenCounterMatcher.GetMatchEnding() + offset;
-				line = line.Left(start) + TEXT("getSeenCounter()") + line.Mid(end);
-				offset += strlen("getSeenCounter()") - (end - start);
-			}
+			//replace "seen"/"unseen"/"seenCounter" with getSeenCounter() calls
+			//(order is safe: none of the patterns match inside the others' output)
+			replaceSeenKeyword(line, seenPattern, TEXT("("), TEXT(" > 0)"));
+			replaceSeenKeyword(line, unseenPattern, TEXT("("), TEXT(" == 0)"));
+			replaceSeenKeyword(line, seenCounterPattern, TEXT(""), TEXT(""));
 
 			//re-compose the string
 			string += line;

--- a/Source/ArticyEditor/Private/ArticyImportData.cpp
+++ b/Source/ArticyEditor/Private/ArticyImportData.cpp
@@ -1446,10 +1446,10 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 	const FRegexPattern unseenPattern(TEXT("\\bunseen\\b"));
 	const FRegexPattern seenCounterPattern(TEXT("\\bseenCounter\\b"));
 
-	// replace a shorthand keyword with a getSeenCounter() call, keeping any optional
-	// (balanced) argument so seen("Obj") hits the name/id overload; Prefix/Suffix wrap it
+	// replace a whole-word shorthand keyword with its getSeenCounter() expansion, but not
+	// inside a string literal (e.g. print text)
 	auto replaceSeenKeyword = [&literalStringPattern](FString& Line, const FRegexPattern& Pattern,
-		const FString& Prefix, const FString& Suffix)
+		const FString& Replacement)
 	{
 		for (int32 searchStart = 0; searchStart <= Line.Len(); )
 		{
@@ -1485,46 +1485,8 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 				continue;
 			}
 
-			// capture an optional balanced (...) argument list following the keyword,
-			// ignoring parens that live inside a string literal
-			int32 cursor = kwEnd;
-			while (cursor < Line.Len() && FChar::IsWhitespace(Line[cursor]))
-				++cursor;
-
-			FString args;
-			int32 replaceEnd = kwEnd;
-			if (cursor < Line.Len() && Line[cursor] == TEXT('('))
-			{
-				int32 depth = 0;
-				bool inString = false;
-				int32 i = cursor;
-				for (; i < Line.Len(); ++i)
-				{
-					const TCHAR c = Line[i];
-					if (inString)
-					{
-						if (c == TEXT('\\'))
-							++i; // skip escaped char
-						else if (c == TEXT('"'))
-							inString = false;
-					}
-					else if (c == TEXT('"'))
-						inString = true;
-					else if (c == TEXT('('))
-						++depth;
-					else if (c == TEXT(')') && --depth == 0)
-					{
-						++i; // move past the matching ')'
-						break;
-					}
-				}
-				args = Line.Mid(cursor + 1, (i - 1) - (cursor + 1)); // contents inside the parens
-				replaceEnd = i;
-			}
-
-			const FString replacement = Prefix + TEXT("getSeenCounter(") + args + TEXT(")") + Suffix;
-			Line = Line.Left(kwStart) + replacement + Line.Mid(replaceEnd);
-			searchStart = kwStart + replacement.Len();
+			Line = Line.Left(kwStart) + Replacement + Line.Mid(kwEnd);
+			searchStart = kwStart + Replacement.Len();
 		}
 	};
 
@@ -1642,9 +1604,9 @@ void UArticyImportData::AddScriptFragment(const FString& Fragment, const bool bI
 
 			// replace "seen"/"unseen"/"seenCounter" with getSeenCounter() calls
 			// (order is safe: none of the patterns match inside the others' output)
-			replaceSeenKeyword(line, seenPattern, TEXT("("), TEXT(" > 0)"));
-			replaceSeenKeyword(line, unseenPattern, TEXT("("), TEXT(" == 0)"));
-			replaceSeenKeyword(line, seenCounterPattern, TEXT(""), TEXT(""));
+			replaceSeenKeyword(line, seenPattern, TEXT("(getSeenCounter() > 0)"));
+			replaceSeenKeyword(line, unseenPattern, TEXT("(getSeenCounter() == 0)"));
+			replaceSeenKeyword(line, seenCounterPattern, TEXT("getSeenCounter()"));
 
 			//re-compose the string
 			string += line;

--- a/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
+++ b/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
@@ -1560,6 +1560,18 @@ void UArticyExpressoScripts::resetAllSeenCounters()
 	}
 }
 
+namespace
+{
+	//the object a seen counter call without an explicit target acts on; while a pin's
+	//script runs, self is the pin, but the counter of interest is the owning node's
+	UArticyBaseObject* ResolveSeenTarget(UArticyPrimitive* Self)
+	{
+		if (auto* Pin = Cast<UArticyFlowPin>(Self))
+			return Pin->GetOwner();
+		return Self;
+	}
+}
+
 /**
  * @brief Retrieves the seen counter for an Articy object.
  *
@@ -1572,7 +1584,7 @@ int UArticyExpressoScripts::getSeenCounter(UArticyBaseObject* Object)
 {
 	if (Object == nullptr)
 	{
-		Object = self;
+		Object = ResolveSeenTarget(self);
 	}
 
 	UArticyGlobalVariables* GVs = GetGV();
@@ -1594,7 +1606,7 @@ int UArticyExpressoScripts::getSeenCounter(UArticyBaseObject* Object)
  */
 int UArticyExpressoScripts::setSeenCounter(const int Value)
 {
-	return setSeenCounter(self, Value);
+	return setSeenCounter(ResolveSeenTarget(self), Value);
 }
 
 /**
@@ -1610,7 +1622,7 @@ int UArticyExpressoScripts::setSeenCounter(UArticyBaseObject* Object, const int 
 {
 	if (Object == nullptr)
 	{
-		Object = self;
+		Object = ResolveSeenTarget(self);
 	}
 
 	UArticyGlobalVariables* GVs = GetGV();

--- a/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
+++ b/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
@@ -1562,8 +1562,8 @@ void UArticyExpressoScripts::resetAllSeenCounters()
 
 namespace
 {
-	//the object a seen counter call without an explicit target acts on; while a pin's
-	//script runs, self is the pin, but the counter of interest is the owning node's
+	// the object a seen counter call without an explicit target acts on; while a pin's
+	// script runs, self is the pin, but the counter of interest is the owning node's
 	UArticyBaseObject* ResolveSeenTarget(UArticyPrimitive* Self)
 	{
 		if (auto* Pin = Cast<UArticyFlowPin>(Self))

--- a/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
+++ b/Source/ArticyRuntime/Private/ArticyExpressoScripts.cpp
@@ -1136,6 +1136,13 @@ bool UArticyExpressoScripts::Execute(const int& InstructionFragmentHash, UArticy
  */
 UArticyObject* UArticyExpressoScripts::getObj(const FString& NameOrId, const uint32& CloneId) const
 {
+	// an object held in a variable is the compound "<id>_<cloneId>" from ExpressoType;
+	// technical names contain underscores too, so only split when both halves are ids
+	FString IdPart, ClonePart;
+	if (NameOrId.Split(TEXT("_"), &IdPart, &ClonePart) && ClonePart.IsNumeric()
+		&& (IdPart.IsNumeric() || IdPart.StartsWith(TEXT("0x"))))
+		return getObj(IdPart, FCString::Atoi(*ClonePart));
+
 	if (NameOrId.StartsWith(TEXT("0x")))
 		return OwningDatabase->GetObject<UArticyObject>(FArticyId{ ArticyHelpers::HexToUint64(NameOrId) }, CloneId);
 	if (NameOrId.IsNumeric())
@@ -1644,7 +1651,15 @@ int UArticyExpressoScripts::setSeenCounter(UArticyBaseObject* Object, const int 
  */
 int UArticyExpressoScripts::getSeenCounter(const FString& NameOrId)
 {
-	return getSeenCounter(getObj(NameOrId, 0));
+	// a failed lookup must not reach the overload below, where nullptr means "use self"
+	auto* Object = getObj(NameOrId, 0);
+	if (!Object)
+	{
+		UE_LOG(LogArticyRuntime, Warning, TEXT("getSeenCounter: could not resolve object %s!"), *NameOrId);
+		return 0;
+	}
+
+	return getSeenCounter(Object);
 }
 
 /**
@@ -1658,7 +1673,15 @@ int UArticyExpressoScripts::getSeenCounter(const FString& NameOrId)
  */
 int UArticyExpressoScripts::setSeenCounter(const FString& NameOrId, const int Value)
 {
-	return setSeenCounter(getObj(NameOrId, 0), Value);
+	// see getSeenCounter(NameOrId): a failed lookup must not fall back to self
+	auto* Object = getObj(NameOrId, 0);
+	if (!Object)
+	{
+		UE_LOG(LogArticyRuntime, Warning, TEXT("setSeenCounter: could not resolve object %s!"), *NameOrId);
+		return 0;
+	}
+
+	return setSeenCounter(Object, Value);
 }
 
 /**

--- a/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
+++ b/Source/ArticyRuntime/Public/ArticyExpressoScripts.h
@@ -954,12 +954,16 @@ protected:
 
     //========================================//
 
+public:
+
     /**
      * @brief The current object for script evaluation.
      *
      * The current object where the script is evaluated on. Do not change the name, as it's called like this in script fragments!
      */
     UArticyPrimitive* self = nullptr;
+
+protected:
 
     /**
      * @brief The speaker for dialog fragments.
@@ -1227,6 +1231,8 @@ protected:
      */
     void resetAllSeenCounters();
 
+public:
+
     /**
      * @brief Retrieves the seen counter for an Articy object.
      *
@@ -1246,6 +1252,8 @@ protected:
      * @return The seen counter value.
      */
     int getSeenCounter(const FString& NameOrId);
+
+protected:
 
     /**
      * @brief Sets the seen counter for the current object.


### PR DESCRIPTION
Two bugs in `AddScriptFragment (ArticyImportData.cpp)`:

- Arguments were dropped. `seen("Obj") generated getSeenCounter() > 0("Obj")` - a compile error. Now the argument is
carried into the call: `(getSeenCounter(FString(TEXT("Obj"))) > 0)`.
- Keywords inside string literals were rewritten. A `print("seen")` message got corrupted (and could break the import). The replacement now skips string literals, matching the existing GV-access handling.