### PR TITLE
fix: unknown cook failure

### DIFF
--- a/Config/DefaultArticyXImporter.ini
+++ b/Config/DefaultArticyXImporter.ini
@@ -2,3 +2,8 @@
 +StructRedirects=(OldName="/Script/ArticyEditor.ArticyPredefinedTypeBase",NewName="/Script/ArticyEditor.ArticyPredefinedTypeBase")
 +PropertyRedirects=(OldName="/Script/ArticyEditor.ArticyTextDef.VOAsset",NewName="/Script/ArticyEditor.ArticyTextDef.VoAsset")
 +StructRedirects=(OldName="/Script/ArticyEditor.ADISettings",NewName="/Script/ArticyEditor.AdiSettings")
++PackageRedirects=(OldName="/ArticyImporter/BP_ArticyFlowDebugger",NewName="/ArticyXImporter/BP_ArticyFlowDebugger")
++PackageRedirects=(OldName="/ArticyImporter/UI/W_ArticyDebugger",NewName="/ArticyXImporter/UI/W_ArticyDebugger")
++PackageRedirects=(OldName="/ArticyImporter/UI/W_ArticyBranchButton",NewName="/ArticyXImporter/UI/W_ArticyBranchButton")
++PackageRedirects=(OldName="/ArticyImporter/Res/ArticyImporter64",NewName="/ArticyXImporter/Res/ArticyImporter64")
++PackageRedirects=(OldName="/ArticyImporter/Res/ArticyImporter16",NewName="/ArticyXImporter/Res/ArticyImporter16")


### PR DESCRIPTION
Adds redirects from older plugin references to address potential cook failures in older projects that were upgraded