### PR TITLE
Fix: Editor crash on Stop-PIE due to Standalone-rooted runtime GV clone

### DIFF
--- a/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
+++ b/Source/ArticyRuntime/Private/ArticyGlobalVariables.cpp
@@ -182,6 +182,18 @@ UArticyGlobalVariables* UArticyGlobalVariables::GetDefault(const UObject* WorldC
             Clone = DuplicateObject<UArticyGlobalVariables>(assetPtr, Cast<UObject>(world), *FString::Printf(TEXT("%s GV"), *world->GetName()));
         }
 
+#if WITH_EDITOR
+        // DuplicateObject copies the source asset's RF_Standalone flag onto the runtime clone,
+        // making the clone a GC root on its own. In the editor that rooted clone can survive
+        // Stop-PIE and pin the now-garbage PIE GameInstance/world it is outered to, tripping
+        // UE's strict PIE leak check (PlayLevel.cpp). Strip the flag so GC can reclaim the clone
+        // together with the world. Packaged builds still AddToRoot above and are unaffected.
+        if (Clone.IsValid())
+        {
+            Clone->ClearFlags(RF_Standalone);
+        }
+#endif
+
         ensureMsgf(Clone.IsValid(), TEXT("Cloning GV asset failed!"));
     }
 
@@ -282,6 +294,15 @@ UArticyGlobalVariables* UArticyGlobalVariables::GetRuntimeClone(const UObject* W
         // Otherwise, add it to the active world
         NewClone = DuplicateObject(assetPtr, Cast<UObject>(world), *FString::Printf(TEXT("%s %s GV"), *world->GetName(), *Name));
     }
+
+#if WITH_EDITOR
+    // See GetDefault: strip the RF_Standalone flag inherited from the asset so the runtime clone
+    // isn't a self-rooting object that survives Stop-PIE and trips UE's PIE leak check.
+    if (NewClone)
+    {
+        NewClone->ClearFlags(RF_Standalone);
+    }
+#endif
 
     // Store and return
     OtherClones.FindOrAdd(Key) = NewClone;


### PR DESCRIPTION
### Summary
Stopping Play-In-Editor (PIE) can crash the editor with an engine assertion:

```
Assertion failed: false [File: Editor\UnrealEd\Private\PlayLevel.cpp] [Line: 546]
Object '<GameInstance>' from PIE level still referenced.
Shortest path from root: (standalone) <ArticyGlobalVariables> ... -> UObject* ... = (Garbage) <GameInstance>
```

### Root cause
`UArticyGlobalVariables::GetDefault()` and `GetRuntimeClone()` create the runtime GV instance via:

```
Clone = DuplicateObject<UArticyGlobalVariables>(assetPtr, Cast<UObject>(world->GetGameInstance()), ...);
```

`DuplicateObject` copies the source asset's object flags onto the clone, including `RF_Standalone`. In a packaged build the clone is also explicitly `AddToRoot()`'d, which is intentional since it should live for the whole game session and PIE never stops there.

In the editor, however, `RF_Standalone` alone already makes the clone a GC root — independent of `AddToRoot()`. Because the clone is outered to the PIE `GameInstance` (or world), that rooted clone keeps the PIE `GameInstance`/world alive after Stop-PIE tears them down. UE's strict Stop-PIE leak check (PlayLevel.cpp) then finds the "dead" `GameInstance` still reachable from a root and asserts, crashing the editor.

This reproduces reliably whenever "keep global variables between worlds" is active (the plugin's own default, and forced on for World Partition maps), and is unrelated to any particular game project's code — it is purely a lifetime issue in how the runtime clone is created.

### Fix
Strip the inherited `RF_Standalone` flag from the runtime clone immediately after creation, in editor builds only (packaged builds are untouched and keep relying on `AddToRoot()`):

```
#if WITH_EDITOR
    if (Clone.IsValid())
    {
        Clone->ClearFlags(RF_Standalone);
    }
#endif
```

applied at both clone sites: the default clone path in `GetDefault()` and the named/"other clones" path in `GetRuntimeClone()`.

With the flag cleared, the runtime clone is no longer a self-rooting object; when the PIE world/`GameInstance` are torn down, normal garbage collection reclaims the clone together with them, and the Stop-PIE leak check no longer finds a stale reference.

### Impact / compatibility
- Editor-only change (`WITH_EDITOR`); packaged/shipping behavior (`AddToRoot()` path) is unchanged.
- No API or behavior change for consumers — the clone's lifetime in a running PIE session is unaffected; only its _survivability_ past Stop-PIE changes (from "leaks and crashes" to "correctly collected").
- Verified locally: this two-line change (applied to both clone sites) resolves a reproducible Stop-PIE crash caused by a Standalone-rooted GV clone pinning the PIE `GameInstance`.

### Repro steps
1. Enable "Keep global variables between worlds" (plugin default), or use a World Partition map (forces it on).
2. Start PIE, let it run, then click Stop.
3. Observe the editor assert/crash in PlayLevel.cpp at the PIE leak check, with the crash callstack naming a `(standalone) <YourGlobalVariables>` object as the shortest GC root path to the "still referenced" PIE `GameInstance`.