### PR TITLE
fix: type system fixes

### DIFF
--- a/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
+++ b/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
@@ -36,7 +36,16 @@ void FArticyTemplateDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonObject
             FArticyTemplateFeatureDef def;
             def.ImportFromJson(item->AsObject(), Data);
             Features.Add(def);
-            ArticyType.Features.Add(def.GetDisplayName());
+            // features are addressed by their technical name, both in tokens and in generated code
+            ArticyType.Features.Add(def.GetTechnicalName());
+
+            // a feature's properties belong to the templated type under their qualified name
+            for (const FArticyPropertyInfo& FeatureProperty : def.GetArticyType().Properties)
+            {
+                FArticyPropertyInfo info = FeatureProperty;
+                info.TechnicalName = def.GetTechnicalName() + TEXT(".") + FeatureProperty.TechnicalName;
+                ArticyType.Properties.Add(info);
+            }
         });
 
     ArticyType.HasTemplate = true;
@@ -129,10 +138,7 @@ void FArticyObjectDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonObjDef, 
             prop.ImportFromJson(item->AsObject(), Data);
             Properties.Add(prop);
 
-            FArticyPropertyInfo info;
-            FString name = prop.GetPropetyName().ToString();
-            info.LocaKey_DisplayName = name;
-            ArticyType.Properties.Add(info);
+            ArticyType.Properties.Add(prop.GetPropertyInfo());
         });
 
     JSON_TRY_OBJECT(JsonObjDef, Values,
@@ -146,6 +152,8 @@ void FArticyObjectDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonObjDef, 
                 Values.Add(val);
 
                 FArticyEnumValueInfo info;
+                info.TechnicalName = val.Name;
+                info.DisplayName = val.Name;
                 info.LocaKey_DisplayName = val.Name;
                 info.Value = val.Value;
                 ArticyType.EnumValues.Add(info);
@@ -157,9 +165,12 @@ void FArticyObjectDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonObjDef, 
             DefType = EObjectDefType::Template;
             Template.ImportFromJson(*obj, Data);
             ArticyType.HasTemplate = true;
+            // fold the feature properties in first, so MergeParent does not copy them again
+            ArticyType.Properties.Append(Template.ArticyType.Properties);
             ArticyType.MergeParent(Template.ArticyType);
         });
 
+    ArticyType.TechnicalName = Type.ToString();
     ArticyType.CPPType = GetCppType(Data, false);
 }
 
@@ -319,6 +330,8 @@ void FArticyObjectDef::InitializeModel(
         ensure(Template.GetDisplayName().IsEmpty());
 
     Model->ArticyType.MergeChild(ArticyType);
+    // the most derived definition runs last, so this ends up naming the model's own type
+    Model->ArticyTypeName = ArticyType.TechnicalName;
 }
 
 /**
@@ -411,6 +424,11 @@ void FArticyPropertyDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonProper
     JSON_TRY_FNAME(JsonProperty, Property);
 
     JSON_TRY_FNAME(JsonProperty, Type);
+
+    // record the declared articy type before localized strings are rewritten to FText below
+    PropertyInfo.TechnicalName = Property.ToString();
+    PropertyInfo.PropertyType = Type.ToString();
+
     //check if this needs to be localized
     //if(Data->GetSettings().set_Localization) //the setting is ignored in the UE plugin
     {
@@ -459,6 +477,8 @@ void FArticyPropertyDef::ImportFromJson(const TSharedPtr<FJsonObject> JsonProper
         DisplayName = Property.ToString();
 
     JSON_TRY_STRING(JsonProperty, Tooltip);
+
+    PropertyInfo.LocaKey_DisplayName = DisplayName;
 
     ArticyType.LocaKey_DisplayName = DisplayName;
     ArticyType.CPPType = GetCppType(Data);
@@ -660,9 +680,8 @@ void FArticyTemplateFeatureDef::ImportFromJson(const TSharedPtr<FJsonObject> Jso
             prop.ImportFromJson(item->AsObject(), Data, &Constraints);
             Properties.Add(prop);
 
-            FArticyPropertyInfo info;
-            FString name = prop.GetPropetyName().ToString();
-            info.LocaKey_DisplayName = name;
+            FArticyPropertyInfo info = prop.GetPropertyInfo();
+            info.IsTemplateProperty = true;
             ArticyType.Properties.Add(info);
         });
 

--- a/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
+++ b/Source/ArticyEditor/Private/ObjectDefinitionsImport.cpp
@@ -827,6 +827,62 @@ void FArticyObjectDefinitions::ImportFromJson(const TArray<TSharedPtr<FJsonValue
                 FeatureDefs.Add(key, feature);
         }
     }
+
+    FlattenInheritedProperties();
+}
+
+/**
+ * Folds each type's inherited properties into its own property list.
+ *
+ * articy declares only the properties a definition introduces, but an object carries its base
+ * classes' properties too, and tokens address them the same way. Runs as a second pass because
+ * a base class may be defined after the types deriving from it.
+ */
+void FArticyObjectDefinitions::FlattenInheritedProperties()
+{
+    // Build every flattened list from the unflattened sources first, so the result does not
+    // depend on the order types happen to be visited in.
+    TMap<FName, TArray<FArticyPropertyInfo>> Flattened;
+
+    for (const auto& Pair : Types)
+    {
+        TArray<FArticyPropertyInfo> Properties = Pair.Value.ArticyType.Properties;
+
+        TSet<FName> Visited;
+        Visited.Add(Pair.Key);
+
+        FName BaseType = Pair.Value.GetBaseClass();
+        while (!BaseType.IsNone() && !Visited.Contains(BaseType))
+        {
+            Visited.Add(BaseType);
+
+            const FArticyObjectDef* BaseDef = Types.Find(BaseType);
+            if (!BaseDef)
+                break;
+
+            // A derived type may redeclare a property; its own definition wins.
+            for (const FArticyPropertyInfo& Inherited : BaseDef->ArticyType.Properties)
+            {
+                const bool bAlreadyDeclared = Properties.ContainsByPredicate(
+                    [&Inherited](const FArticyPropertyInfo& Existing)
+                    {
+                        return Existing.TechnicalName.Equals(Inherited.TechnicalName);
+                    });
+
+                if (!bAlreadyDeclared)
+                    Properties.Add(Inherited);
+            }
+
+            BaseType = BaseDef->GetBaseClass();
+        }
+
+        Flattened.Add(Pair.Key, MoveTemp(Properties));
+    }
+
+    for (auto& Pair : Types)
+    {
+        Pair.Value.ArticyType.Properties = MoveTemp(Flattened[Pair.Key]);
+    }
 }
 
 /**

--- a/Source/ArticyEditor/Private/Tests/ArticyIntegrationSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ArticyIntegrationSpec.cpp
@@ -7,6 +7,7 @@
 #include "ArticyGlobalVariables.h"
 #include "ArticyObject.h"
 #include "ArticyTextExtension.h"
+#include "ArticyTypeSystem.h"
 #include "ArticyFlowPlayer.h"
 #include "GameFramework/Actor.h"
 #include "Editor.h"
@@ -198,8 +199,79 @@ void FArticyIntegrationSpec::Define()
 			TestTrue(TEXT("looks like the z-index value"), Res.Contains(TEXT("4")));
 		});
 
-		// NOTE: a [$Type.Type.Property] token test is intentionally absent; that feature is
-		// non-functional because UArticyTypeSystem::Types is never populated at runtime.
+		It("resolves a [$Type.Type.Property] token to the property's type", [this]()
+		{
+			UWorld* World = GetIntegrationWorld();
+			if (!TestNotNull(TEXT("editor world"), World))
+				return;
+
+			UArticyDatabase* DB = UArticyDatabase::Get(World);
+			if (!TestNotNull(TEXT("database"), DB))
+				return;
+
+			UArticyObject* Entity = DB->GetObjectByName(FName(DemoEntity));
+			if (!Entity)
+			{
+				AddWarning(MissingContentMessage(DemoEntity));
+				return;
+			}
+
+			// Ask the object what type it is, then ask the type system about that type:
+			// both halves of the metadata layer have to be populated for this to resolve.
+			const FArticyType Type = Entity->GetArticyType();
+			if (Type.TechnicalName.IsEmpty())
+			{
+				AddWarning(MissingContentMessage(FString::Printf(TEXT("type metadata for '%s' (reimport needed?)"), DemoEntity)));
+				return;
+			}
+
+			const FString Token = FString::Printf(TEXT("$Type.%s.%s"), *Type.TechnicalName, DemoEntityProperty);
+			const FText Format = FText::FromString(FString::Printf(TEXT("[%s]"), *Token));
+			const FString Res = UArticyTextExtension::Get()->Resolve(World, &Format).ToString();
+
+			// On lookup failure the resolver returns the raw source name.
+			TestNotEqual(TEXT("resolved, not the raw fallback"), Res, Token);
+			TestFalse(TEXT("result not empty"), Res.IsEmpty());
+		});
+	});
+
+	Describe("Type system", [this]()
+	{
+		It("populates the type map from the imported project", [this]()
+		{
+			UArticyTypeSystem* TypeSystem = UArticyTypeSystem::Get();
+			if (!TestNotNull(TEXT("type system"), TypeSystem))
+				return;
+
+			TestTrue(TEXT("types imported - has the project been reimported since upgrading?"),
+				TypeSystem->Types.Num() > 0);
+		});
+
+		It("gives an imported object a non-empty type", [this]()
+		{
+			UWorld* World = GetIntegrationWorld();
+			if (!TestNotNull(TEXT("editor world"), World))
+				return;
+
+			UArticyDatabase* DB = UArticyDatabase::Get(World);
+			if (!TestNotNull(TEXT("database"), DB))
+				return;
+
+			UArticyObject* Entity = DB->GetObjectByName(FName(DemoEntity));
+			if (!Entity)
+			{
+				AddWarning(MissingContentMessage(DemoEntity));
+				return;
+			}
+
+			const FArticyType Type = Entity->GetArticyType();
+			TestFalse(TEXT("has a technical name"), Type.TechnicalName.IsEmpty());
+			TestTrue(TEXT("has properties"), Type.GetProperties().Num() > 0);
+
+			// The property the object-property test reads must be described by the type.
+			TestEqual(TEXT("property is described"), Type.GetProperty(DemoEntityProperty).TechnicalName,
+				FString(DemoEntityProperty));
+		});
 	});
 
 	Describe("Flow player", [this]()

--- a/Source/ArticyEditor/Private/Tests/ArticyObjectDefSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ArticyObjectDefSpec.cpp
@@ -66,6 +66,66 @@ void FArticyObjectDefSpec::Define()
 			TestEqual(TEXT("cpp type"), Def.GetCppType(Data, false), FString(TEXT("UNPC")));
 		});
 	});
+
+	// What the importer hands to the type system, and therefore what a
+	// [$Type.<Type>.<Property>] token and UArticyBaseObject::GetArticyType() see.
+	Describe("ArticyType", [this]()
+	{
+		It("names the type and describes its own properties", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Type"), TEXT("MyEntity"));
+			Json->SetStringField(TEXT("Class"), TEXT("Entity"));
+			Json->SetArrayField(TEXT("Properties"), TestJson::OneObject(TestJson::PropJson(TEXT("Health"), TEXT("int"))));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyObjectDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			// The technical name has to match the key the type is registered under.
+			TestEqual(TEXT("technical name"), Def.ArticyType.TechnicalName, Def.GetOriginalType().ToString());
+			TestEqual(TEXT("cpp type"), Def.ArticyType.CPPType, FString(TEXT("UMyEntity")));
+			TestEqual(TEXT("property type"), Def.ArticyType.GetProperty(TEXT("Health")).PropertyType, FString(TEXT("int")));
+		});
+
+		It("describes both its own and its template's properties", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Type"), TEXT("NPC"));
+			Json->SetStringField(TEXT("Class"), TEXT("Entity"));
+			Json->SetArrayField(TEXT("Properties"), TestJson::OneObject(TestJson::PropJson(TEXT("DisplayName"), TEXT("string"))));
+			Json->SetObjectField(TEXT("Template"), TestJson::TemplateJson(TEXT("NPCTemplate"), TEXT("NPC")));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyObjectDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			TestEqual(TEXT("own property"), Def.ArticyType.GetProperty(TEXT("DisplayName")).PropertyType, FString(TEXT("string")));
+			TestEqual(TEXT("feature property"), Def.ArticyType.GetProperty(TEXT("Stats.HP")).PropertyType, FString(TEXT("int")));
+			TestEqual(TEXT("property count"), Def.ArticyType.GetProperties().Num(), 2);
+			TestEqual(TEXT("feature count"), Def.ArticyType.Features.Num(), 1);
+			TestTrue(TEXT("feature listed by technical name"), Def.ArticyType.Features.Contains(TEXT("Stats")));
+		});
+
+		It("describes enum values by technical name", [this]()
+		{
+			TSharedPtr<FJsonObject> Values = MakeShared<FJsonObject>();
+			Values->SetNumberField(TEXT("Happy"), 0);
+			Values->SetNumberField(TEXT("Sad"), 1);
+
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Type"), TEXT("Mood"));
+			Json->SetObjectField(TEXT("Values"), Values);
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyObjectDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			TestTrue(TEXT("is enum"), Def.ArticyType.IsEnum);
+			TestEqual(TEXT("by name"), Def.ArticyType.GetEnumValue(FString(TEXT("Sad"))).Value, 1);
+			TestEqual(TEXT("by value"), Def.ArticyType.GetEnumValue(0).TechnicalName, FString(TEXT("Happy")));
+		});
+	});
 }
 
 #endif // WITH_AUTOMATION_TESTS

--- a/Source/ArticyEditor/Private/Tests/ArticyPropertyDefSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ArticyPropertyDefSpec.cpp
@@ -44,6 +44,58 @@ void FArticyPropertyDefSpec::Define()
 			TestEqual(TEXT("promoted to FText"), Def.GetOriginalType().ToString(), FString(TEXT("FText")));
 		});
 	});
+
+	// The type system describes properties in articy's own terms; this is what a
+	// [$Type.<Type>.<Property>] token resolves to.
+	Describe("GetPropertyInfo", [this]()
+	{
+		It("describes the property by its technical name and declared type", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Property"), TEXT("Health"));
+			Json->SetStringField(TEXT("Type"), TEXT("int"));
+			Json->SetStringField(TEXT("DisplayName"), TEXT("NPC.Health.DisplayName"));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyPropertyDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			const FArticyPropertyInfo& Info = Def.GetPropertyInfo();
+			TestEqual(TEXT("technical name"), Info.TechnicalName, FString(TEXT("Health")));
+			TestEqual(TEXT("property type"), Info.PropertyType, FString(TEXT("int")));
+			TestEqual(TEXT("loca key"), Info.LocaKey_DisplayName, FString(TEXT("NPC.Health.DisplayName")));
+			TestFalse(TEXT("not a template property"), Info.IsTemplateProperty);
+		});
+
+		It("reports the articy type of a localized property, not its C++ type", [this]()
+		{
+			// The def itself promotes localized strings to FText so the generated code gets
+			// the right C++ type; the type system keeps reporting what articy declared.
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Property"), TEXT("DisplayName"));
+			Json->SetStringField(TEXT("Type"), TEXT("string"));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyPropertyDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			TestEqual(TEXT("cpp type promoted"), Def.GetOriginalType().ToString(), FString(TEXT("FText")));
+			TestEqual(TEXT("articy type kept"), Def.GetPropertyInfo().PropertyType, FString(TEXT("string")));
+		});
+
+		It("falls back to the property name when no display name is given", [this]()
+		{
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Property"), TEXT("Health"));
+			Json->SetStringField(TEXT("Type"), TEXT("int"));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyPropertyDef Def;
+			Def.ImportFromJson(Json, Data);
+
+			TestEqual(TEXT("loca key"), Def.GetPropertyInfo().LocaKey_DisplayName, FString(TEXT("Health")));
+		});
+	});
 }
 
 #endif // WITH_AUTOMATION_TESTS

--- a/Source/ArticyEditor/Private/Tests/ArticyTemplateDefSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ArticyTemplateDefSpec.cpp
@@ -33,6 +33,33 @@ void FArticyTemplateDefSpec::Define()
 				TestEqual(TEXT("feature name"), Template.GetFeatures()[0].GetTechnicalName(), FString(TEXT("Stats")));
 			}
 		});
+
+		It("lists its features by technical name in the type", [this]()
+		{
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyTemplateDef Template;
+			Template.ImportFromJson(TestJson::TemplateJson(TEXT("NPCTemplate"), TEXT("NPC")), Data);
+
+			// Technical names, because that is how tokens and generated properties
+			// address a feature.
+			TestEqual(TEXT("feature count"), Template.ArticyType.Features.Num(), 1);
+			TestTrue(TEXT("listed by technical name"), Template.ArticyType.Features.Contains(TEXT("Stats")));
+			TestTrue(TEXT("has template"), Template.ArticyType.HasTemplate);
+		});
+
+		It("adopts the feature properties under their qualified names", [this]()
+		{
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyTemplateDef Template;
+			Template.ImportFromJson(TestJson::TemplateJson(TEXT("NPCTemplate"), TEXT("NPC")), Data);
+
+			const FArticyPropertyInfo Info = Template.ArticyType.GetProperty(TEXT("Stats.HP"));
+			TestEqual(TEXT("qualified name"), Info.TechnicalName, FString(TEXT("Stats.HP")));
+			TestEqual(TEXT("property type"), Info.PropertyType, FString(TEXT("int")));
+
+			const TArray<FArticyPropertyInfo> InFeature = Template.ArticyType.GetPropertiesInFeature(TEXT("Stats"));
+			TestEqual(TEXT("properties in feature"), InFeature.Num(), 1);
+		});
 	});
 }
 

--- a/Source/ArticyEditor/Private/Tests/ArticyTemplateFeatureDefSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ArticyTemplateFeatureDefSpec.cpp
@@ -30,6 +30,19 @@ void FArticyTemplateFeatureDefSpec::Define()
 			TestEqual(TEXT("display name"), Feature.GetDisplayName(), FString(TEXT("Stats Feature")));
 			TestEqual(TEXT("cpp type"), Feature.GetCppType(Data, false), FString(TEXT("UStatsFeature")));
 		});
+
+		It("describes its properties as template properties", [this]()
+		{
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyTemplateFeatureDef Feature;
+			Feature.ImportFromJson(TestJson::FeatureJson(TEXT("Stats"), TEXT("Stats Feature")), Data);
+
+			// Names are unqualified here; the owning template is what prefixes them with
+			// the feature name.
+			const FArticyPropertyInfo Info = Feature.GetArticyType().GetProperty(TEXT("HP"));
+			TestEqual(TEXT("property type"), Info.PropertyType, FString(TEXT("int")));
+			TestTrue(TEXT("is a template property"), Info.IsTemplateProperty);
+		});
 	});
 }
 

--- a/Source/ArticyEditor/Private/Tests/ObjectDefinitionsLookupSpec.cpp
+++ b/Source/ArticyEditor/Private/Tests/ObjectDefinitionsLookupSpec.cpp
@@ -170,6 +170,78 @@ void FArticyObjectDefLookupSpec::Define()
 				FArticyObjectDefinitions::GetCppDefaultValue(FName(TEXT("MyNpcTemplate"))).IsEmpty());
 		});
 	});
+
+	// An object carries the properties of its base classes, so its type has to describe them
+	// too - a [$Type.<Template>.DisplayName] token asks about a property declared on Entity.
+	Describe("inherited properties", [this]()
+	{
+		const auto TypeJson = [](const FString& Type, const FString& Class, const FString& Property)
+		{
+			TSharedPtr<FJsonObject> Prop = MakeShared<FJsonObject>();
+			Prop->SetStringField(TEXT("Property"), Property);
+			Prop->SetStringField(TEXT("Type"), TEXT("string"));
+
+			TArray<TSharedPtr<FJsonValue>> Props;
+			Props.Add(MakeShared<FJsonValueObject>(Prop));
+
+			TSharedPtr<FJsonObject> Json = MakeShared<FJsonObject>();
+			Json->SetStringField(TEXT("Type"), Type);
+			Json->SetStringField(TEXT("Class"), Class);
+			Json->SetArrayField(TEXT("Properties"), Props);
+			return MakeShared<FJsonValueObject>(Json);
+		};
+
+		It("folds a base class's properties into the derived type", [this, TypeJson]()
+		{
+			// Derived type listed first, so the pass cannot rely on definition order.
+			TArray<TSharedPtr<FJsonValue>> Json;
+			Json.Add(TypeJson(TEXT("Character"), TEXT("Entity"), TEXT("Motivation")));
+			Json.Add(TypeJson(TEXT("Entity"), TEXT("Entity"), TEXT("DisplayName")));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyObjectDefinitions Defs;
+			Defs.ImportFromJson(&Json, Data);
+
+			const FArticyObjectDef* Character = Defs.GetTypes().Find(FName(TEXT("Character")));
+			if (!TestNotNull(TEXT("Character type"), Character))
+				return;
+
+			TestEqual(TEXT("own property"),
+				Character->ArticyType.GetProperty(TEXT("Motivation")).PropertyType, FString(TEXT("string")));
+			TestEqual(TEXT("inherited property"),
+				Character->ArticyType.GetProperty(TEXT("DisplayName")).PropertyType, FString(TEXT("string")));
+		});
+
+		It("keeps a derived type's own declaration when it redeclares a base property", [this, TypeJson]()
+		{
+			TArray<TSharedPtr<FJsonValue>> Json;
+			Json.Add(TypeJson(TEXT("Entity"), TEXT("Entity"), TEXT("DisplayName")));
+
+			TSharedPtr<FJsonObject> OwnProp = MakeShared<FJsonObject>();
+			OwnProp->SetStringField(TEXT("Property"), TEXT("DisplayName"));
+			OwnProp->SetStringField(TEXT("Type"), TEXT("int"));
+			TArray<TSharedPtr<FJsonValue>> Props;
+			Props.Add(MakeShared<FJsonValueObject>(OwnProp));
+
+			TSharedPtr<FJsonObject> Derived = MakeShared<FJsonObject>();
+			Derived->SetStringField(TEXT("Type"), TEXT("Character"));
+			Derived->SetStringField(TEXT("Class"), TEXT("Entity"));
+			Derived->SetArrayField(TEXT("Properties"), Props);
+			Json.Add(MakeShared<FJsonValueObject>(Derived));
+
+			UArticyImportData* Data = NewObject<UArticyImportData>();
+			FArticyObjectDefinitions Defs;
+			Defs.ImportFromJson(&Json, Data);
+
+			const FArticyObjectDef* Character = Defs.GetTypes().Find(FName(TEXT("Character")));
+			if (!TestNotNull(TEXT("Character type"), Character))
+				return;
+
+			TestEqual(TEXT("own declaration wins"),
+				Character->ArticyType.GetProperty(TEXT("DisplayName")).PropertyType, FString(TEXT("int")));
+			TestEqual(TEXT("not duplicated"), Character->ArticyType.GetProperties().Num(), 1);
+		});
+	});
 }
 
 #endif // WITH_AUTOMATION_TESTS

--- a/Source/ArticyEditor/Public/ObjectDefinitionsImport.h
+++ b/Source/ArticyEditor/Public/ObjectDefinitionsImport.h
@@ -114,6 +114,13 @@ public:
     const FName& GetOriginalItemType() const { return ItemType; }
 
     /**
+     * Returns the type system metadata describing this property.
+     *
+     * @return The property info for this property.
+     */
+    const FArticyPropertyInfo& GetPropertyInfo() const { return PropertyInfo; }
+
+    /**
      * Returns the C++ type of the property definition.
      *
      * @param Data A pointer to the UArticyImportData object.
@@ -136,6 +143,9 @@ private:
 
     UPROPERTY(VisibleAnywhere, Category = "ObjectProperty")
     FArticyType ArticyType;
+
+    UPROPERTY(VisibleAnywhere, Category = "ObjectProperty")
+    FArticyPropertyInfo PropertyInfo;
 
     friend class UArticyImportData;
 };
@@ -249,6 +259,13 @@ public:
      * @return The display name as a string.
      */
     FString GetDisplayName() const { return DisplayName; }
+
+    /**
+     * Returns the type system metadata describing this feature.
+     *
+     * @return The Articy type of this feature.
+     */
+    const FArticyType& GetArticyType() const { return ArticyType; }
 
 private:
     UPROPERTY(VisibleAnywhere, Category = "TemplateFeature")

--- a/Source/ArticyEditor/Public/ObjectDefinitionsImport.h
+++ b/Source/ArticyEditor/Public/ObjectDefinitionsImport.h
@@ -462,6 +462,13 @@ public:
     const FName& GetOriginalType() const { return Type; }
 
     /**
+     * Returns the base class this definition derives its inherited properties from.
+     *
+     * @return The base class as an FName.
+     */
+    const FName& GetBaseClass() const { return Class; }
+
+    /**
      * Returns the features of the object definition.
      *
      * @return A constant reference to the array of features.
@@ -510,6 +517,14 @@ public:
      * @param Data A pointer to the UArticyImportData object.
      */
     void ImportFromJson(const TArray<TSharedPtr<FJsonValue>>* Json, const UArticyImportData* Data);
+
+    /**
+     * Folds each type's inherited properties into its own property list.
+     *
+     * Runs after all definitions are parsed, since a base class may be declared after the
+     * types that derive from it.
+     */
+    void FlattenInheritedProperties();
 
     /**
      * Gather scripts from model definition and adds them to the UArticyImportData.

--- a/Source/ArticyRuntime/Private/ArticyBaseObject.cpp
+++ b/Source/ArticyRuntime/Private/ArticyBaseObject.cpp
@@ -30,12 +30,26 @@ void UArticyBaseObject::AddSubobject(UArticyPrimitive* Obj)
 }
 
 /**
- * Gets the Articy type of this object.
+ * Gets the Articy type of this object, resolved through the type system.
  *
  * @return The FArticyType associated with this object.
  */
 FArticyType UArticyBaseObject::GetArticyType() const
 {
+	if (!ArticyTypeName.IsEmpty())
+	{
+		if (const UArticyTypeSystem* TypeSystem = UArticyTypeSystem::Get())
+		{
+			const FArticyType Type = TypeSystem->GetArticyType(ArticyTypeName);
+			if (!Type.TechnicalName.IsEmpty())
+			{
+				return Type;
+			}
+		}
+	}
+
+	// Falls back to the locally assembled type, which is all the importer has to work with
+	// while it is still generating the type system asset.
 	return ArticyType;
 }
 

--- a/Source/ArticyRuntime/Private/ArticyTextExtension.cpp
+++ b/Source/ArticyRuntime/Private/ArticyTextExtension.cpp
@@ -87,11 +87,26 @@ FString UArticyTextExtension::GetSource(UObject* Outer, const FString& SourceNam
 		}
 	}
 
-	// Process types
-	if (SourceParts[0].StartsWith(TEXT("$Type.")))
+	// Process types: [$Type.<TypeName>.<Property>], where the property may be qualified with
+	// the feature it lives in. SourceName is already split on dots, so the marker is its own part.
+	if (SourceParts[0].Equals(TEXT("$Type")))
 	{
-		const FString TypeName = SourceParts[0].Mid(6);
-		GetTypeProperty(TypeName, RemValue, Result, bSuccess);
+		if (SourceParts.Num() < 3)
+		{
+			return SourceName;
+		}
+
+		FString PropertyName;
+		for (int32 Index = 2; Index < SourceParts.Num(); ++Index)
+		{
+			if (!PropertyName.IsEmpty())
+			{
+				PropertyName += TEXT(".");
+			}
+			PropertyName += SourceParts[Index];
+		}
+
+		GetTypeProperty(SourceParts[1], PropertyName, Result, bSuccess);
 
 		if (bSuccess)
 		{
@@ -289,7 +304,14 @@ void UArticyTextExtension::GetObjectProperty(UObject* Outer, const FString& Sour
 
 	if (bRequestType)
 	{
-		OutString = Object->ArticyType.GetProperty(PropertyName).PropertyType;
+		const FArticyPropertyInfo PropertyInfo = Object->GetArticyType().GetProperty(PropertyName);
+		if (PropertyInfo.TechnicalName.IsEmpty())
+		{
+			OutSuccess = false;
+			return;
+		}
+
+		OutString = PropertyInfo.PropertyType;
 		OutSuccess = true;
 		return;
 	}
@@ -331,22 +353,15 @@ void UArticyTextExtension::GetObjectProperty(UObject* Outer, const FString& Sour
 void UArticyTextExtension::GetTypeProperty(const FString& TypeName, const FString& PropertyName, FString& OutString,
 	bool& OutSuccess)
 {
-	UArticyTypeSystem* TypeSystem = UArticyTypeSystem::Get();
-	FArticyType TypeData = TypeSystem->GetArticyType(TypeName);
-	FArticyPropertyInfo PropertyInfo{};
-	bool bFoundProperty = false;
-	
-	for (const auto& Property : TypeData.Properties)
+	const UArticyTypeSystem* TypeSystem = UArticyTypeSystem::Get();
+	if (!TypeSystem)
 	{
-		if (Property.TechnicalName.Equals(PropertyName))
-		{
-			PropertyInfo = Property;
-			bFoundProperty = true;
-			break;
-		}
+		OutSuccess = false;
+		return;
 	}
 
-	if (!bFoundProperty)
+	const FArticyPropertyInfo PropertyInfo = TypeSystem->GetArticyType(TypeName).GetProperty(PropertyName);
+	if (PropertyInfo.TechnicalName.IsEmpty())
 	{
 		OutSuccess = false;
 		return;

--- a/Source/ArticyRuntime/Private/ArticyType.cpp
+++ b/Source/ArticyRuntime/Private/ArticyType.cpp
@@ -21,7 +21,7 @@ FArticyEnumValueInfo FArticyType::GetEnumValue(const FString& ValueName) const
 {
 	for (const auto& EnumInfo : EnumValues)
 	{
-		if (EnumInfo.LocaKey_DisplayName.Equals(ValueName))
+		if (EnumInfo.TechnicalName.Equals(ValueName))
 		{
 			return EnumInfo;
 		}
@@ -46,15 +46,25 @@ TArray<FArticyPropertyInfo> FArticyType::GetProperties() const
 
 TArray<FArticyPropertyInfo> FArticyType::GetPropertiesInFeature(const FString& FeatureName) const
 {
-	// TODO: Implement this functionality
-	return {};
+	// Feature properties are stored under their qualified "<Feature>.<Property>" name.
+	const FString Prefix = FeatureName + TEXT(".");
+
+	TArray<FArticyPropertyInfo> Result;
+	for (const auto& PropertyInfo : Properties)
+	{
+		if (PropertyInfo.IsTemplateProperty && PropertyInfo.TechnicalName.StartsWith(Prefix))
+		{
+			Result.Add(PropertyInfo);
+		}
+	}
+	return Result;
 }
 
 FArticyPropertyInfo FArticyType::GetProperty(const FString& PropertyName) const
 {
 	for (const auto& PropertyInfo : Properties)
 	{
-		if (PropertyInfo.LocaKey_DisplayName.Equals(PropertyName))
+		if (PropertyInfo.TechnicalName.Equals(PropertyName))
 		{
 			return PropertyInfo;
 		}

--- a/Source/ArticyRuntime/Private/ArticyTypeSystem.cpp
+++ b/Source/ArticyRuntime/Private/ArticyTypeSystem.cpp
@@ -5,11 +5,66 @@
 #include "ArticyTypeSystem.h"
 
 #include "ArticyDatabase.h"
+#include "ArticyRuntimeModule.h"
 #include "ArticyType.h"
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >0
+#include "AssetRegistry/AssetRegistryModule.h"
+#else
+#include "AssetRegistryModule.h"
+#endif
+
+namespace
+{
+	// The importer fills the type map on a generated <Project>TypeSystem asset that derives
+	// from UArticyTypeSystem; the base class itself is never saved as an asset.
+	UArticyTypeSystem* FindGeneratedTypeSystem()
+	{
+		FAssetRegistryModule& AssetRegistryModule = FModuleManager::LoadModuleChecked<FAssetRegistryModule>("AssetRegistry");
+		TArray<FAssetData> AssetData;
+
+#if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION >0
+		AssetRegistryModule.Get().GetAssetsByClass(UArticyTypeSystem::StaticClass()->GetClassPathName(), AssetData, true);
+#else
+		AssetRegistryModule.Get().GetAssetsByClass(UArticyTypeSystem::StaticClass()->GetFName(), AssetData, true);
+#endif
+
+		if (AssetData.Num() > 1)
+		{
+			UE_LOG(LogArticyRuntime, Warning, TEXT("More than one ArticyTypeSystem was found, this is not supported! The first one will be selected."));
+		}
+
+		for (const FAssetData& Asset : AssetData)
+		{
+			if (UArticyTypeSystem* TypeSystem = Cast<UArticyTypeSystem>(Asset.GetAsset()))
+			{
+				return TypeSystem;
+			}
+		}
+
+		return nullptr;
+	}
+}
 
 UArticyTypeSystem* UArticyTypeSystem::Get()
 {
 	static TWeakObjectPtr<UArticyTypeSystem> ArticyTypeSystem;
+	static bool bIsGenerated = false;
+
+	if (!ArticyTypeSystem.IsValid())
+	{
+		bIsGenerated = false;
+	}
+
+	// Keep looking while we only hold the empty placeholder: the generated asset does not
+	// exist before the first import, and the asset registry may still be scanning.
+	if (!bIsGenerated)
+	{
+		if (UArticyTypeSystem* Generated = FindGeneratedTypeSystem())
+		{
+			ArticyTypeSystem = Generated;
+			bIsGenerated = true;
+		}
+	}
 
 	if (!ArticyTypeSystem.IsValid())
 	{
@@ -21,9 +76,9 @@ UArticyTypeSystem* UArticyTypeSystem::Get()
 
 FArticyType UArticyTypeSystem::GetArticyType(const FString& TypeName) const
 {
-	if (Types.Contains(TypeName))
+	if (const FArticyType* Type = Types.Find(TypeName))
 	{
-		return Types[TypeName];
+		return *Type;
 	}
 
 	return {};

--- a/Source/ArticyRuntime/Public/ArticyBaseObject.h
+++ b/Source/ArticyRuntime/Public/ArticyBaseObject.h
@@ -42,14 +42,21 @@ public:
 	UArticyPrimitive* GetSubobject(FArticyId Id) const;
 
 	/**
-	 * Gets the Articy type of this object.
+	 * Gets the Articy type of this object, resolved through the type system.
 	 *
 	 * @return The FArticyType associated with this object.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Articy")
 	FArticyType GetArticyType() const;
 
-	/** The Articy type of this object. */
+	/**
+	 * The technical name of this object's Articy type. Only the name is serialized; the type
+	 * metadata itself is shared through the type system instead of copied onto every object.
+	 */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Articy")
+	FString ArticyTypeName;
+
+	/** Type metadata assembled by the importer, before the type system is available. */
 	FArticyType ArticyType;
 
 protected:

--- a/Source/ArticyRuntime/Public/ArticyTypeSystem.h
+++ b/Source/ArticyRuntime/Public/ArticyTypeSystem.h
@@ -14,7 +14,22 @@ class ARTICYRUNTIME_API UArticyTypeSystem : public UObject
 	GENERATED_BODY()
 
 public:
+	/**
+	 * Retrieves the type system instance. This is the generated <Project>TypeSystem asset
+	 * if the project has been imported, otherwise an empty placeholder.
+	 */
 	static UArticyTypeSystem* Get();
+
+	/**
+	 * Retrieves the metadata for an articy type by its technical name.
+	 *
+	 * @param TypeName The technical name of the type, e.g. "Entity" or a template name.
+	 * @return The type metadata, or a default-constructed one if the type is unknown.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Articy")
 	FArticyType GetArticyType(const FString& TypeName) const;
+
+	/** Type metadata by technical name, filled by the importer on the generated asset. */
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Articy")
 	TMap<FString, FArticyType> Types;
 };

--- a/Source/ArticyTests/Private/Runtime/ArticyTextExtensionSpec.cpp
+++ b/Source/ArticyTests/Private/Runtime/ArticyTextExtensionSpec.cpp
@@ -4,11 +4,17 @@
 
 #include "Misc/AutomationTest.h"
 #include "ArticyTextExtension.h"
+#include "ArticyTypeSystem.h"
+#include "UObject/StrongObjectPtr.h"
 
 #if WITH_AUTOMATION_TESTS
 
 BEGIN_DEFINE_SPEC(FArticyTextExtensionSpec, "Articy.Runtime.TextExtension",
 	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+	// Held across a $Type test so the singleton the resolver looks up cannot be collected
+	// between registering a type and resolving against it.
+	TStrongObjectPtr<UArticyTypeSystem> TypeSystem;
+	TMap<FString, FArticyType> SavedTypes;
 END_DEFINE_SPEC(FArticyTextExtensionSpec)
 
 void FArticyTextExtensionSpec::Define()
@@ -104,12 +110,8 @@ void FArticyTextExtensionSpec::Define()
 				FString(TEXT("GameState.Flag")));
 		});
 
-		It("returns the source name for a $Type lookup", [this]()
+		It("returns the source name for an unknown $Type lookup", [this]()
 		{
-			// Note: the $Type branch inside GetSource tests SourceParts[0] against the
-			// prefix "$Type.", but SourceName has already been split on dots by then, so
-			// SourceParts[0] is only ever "$Type" and the branch cannot be taken. A $Type
-			// token therefore falls all the way through to the source-name fallback.
 			TestEqual(TEXT("type"), UArticyTextExtension::Get()->Test_GetSource(nullptr, TEXT("$Type.Nope.DisplayName")),
 				FString(TEXT("$Type.Nope.DisplayName")));
 		});
@@ -117,6 +119,84 @@ void FArticyTextExtensionSpec::Define()
 		It("returns an empty string for an empty source name", [this]()
 		{
 			TestEqual(TEXT("empty"), UArticyTextExtension::Get()->Test_GetSource(nullptr, FString()), FString());
+		});
+	});
+
+	// [$Type.<TypeName>.<Property>] resolves to the property's declared type through the
+	// type system. Unit tests run in a host project with no imported articy content, so the
+	// type system singleton is the empty placeholder and the spec can register types on it.
+	Describe("$Type tokens", [this]()
+	{
+		// Regression: GetSource tested the already-split first part against the prefix
+		// "$Type.", which can never match, so every $Type token fell through unresolved.
+		BeforeEach([this]()
+		{
+			TypeSystem.Reset(UArticyTypeSystem::Get());
+			if (TypeSystem.IsValid())
+			{
+				SavedTypes = TypeSystem->Types;
+
+				FArticyPropertyInfo DisplayName;
+				DisplayName.TechnicalName = TEXT("DisplayName");
+				DisplayName.PropertyType = TEXT("string");
+
+				FArticyPropertyInfo Motivation;
+				Motivation.TechnicalName = TEXT("Character.Motivation");
+				Motivation.PropertyType = TEXT("int");
+				Motivation.IsTemplateProperty = true;
+
+				FArticyType Character;
+				Character.TechnicalName = TEXT("Character");
+				Character.Properties = { DisplayName, Motivation };
+
+				TypeSystem->Types.Add(TEXT("Character"), Character);
+			}
+		});
+
+		AfterEach([this]()
+		{
+			if (TypeSystem.IsValid())
+			{
+				TypeSystem->Types = SavedTypes;
+			}
+			TypeSystem.Reset();
+			SavedTypes.Reset();
+		});
+
+		It("resolves a type property to its declared type", [this]()
+		{
+			const FText Format = FText::FromString(TEXT("[$Type.Character.DisplayName]"));
+			TestEqual(TEXT("resolved"), UArticyTextExtension::Get()->Resolve(nullptr, &Format).ToString(),
+				FString(TEXT("string")));
+		});
+
+		It("resolves a feature property by its qualified name", [this]()
+		{
+			const FText Format = FText::FromString(TEXT("[$Type.Character.Character.Motivation]"));
+			TestEqual(TEXT("resolved"), UArticyTextExtension::Get()->Resolve(nullptr, &Format).ToString(),
+				FString(TEXT("int")));
+		});
+
+		It("resolves a $Type token without a world context", [this]()
+		{
+			// Type metadata is world-independent, unlike variables and objects.
+			TestEqual(TEXT("no world"), UArticyTextExtension::Get()->Test_GetSource(nullptr, TEXT("$Type.Character.DisplayName")),
+				FString(TEXT("string")));
+		});
+
+		It("falls back to the source name for an unknown property", [this]()
+		{
+			TestEqual(TEXT("unknown property"),
+				UArticyTextExtension::Get()->Test_GetSource(nullptr, TEXT("$Type.Character.Nope")),
+				FString(TEXT("$Type.Character.Nope")));
+		});
+
+		It("falls back to the source name when no property is named", [this]()
+		{
+			TestEqual(TEXT("no property"), UArticyTextExtension::Get()->Test_GetSource(nullptr, TEXT("$Type.Character")),
+				FString(TEXT("$Type.Character")));
+			TestEqual(TEXT("marker only"), UArticyTextExtension::Get()->Test_GetSource(nullptr, TEXT("$Type")),
+				FString(TEXT("$Type")));
 		});
 	});
 

--- a/Source/ArticyTests/Private/Runtime/ArticyTypeSpec.cpp
+++ b/Source/ArticyTests/Private/Runtime/ArticyTypeSpec.cpp
@@ -9,19 +9,32 @@
 
 namespace
 {
-	FArticyEnumValueInfo MakeEnumValue(const FString& LocaKey, int Value)
+	FArticyEnumValueInfo MakeEnumValue(const FString& TechnicalName, int Value)
 	{
 		FArticyEnumValueInfo Info;
-		Info.LocaKey_DisplayName = LocaKey;
+		Info.TechnicalName = TechnicalName;
+		Info.DisplayName = TechnicalName;
+		Info.LocaKey_DisplayName = TechnicalName;
 		Info.Value = Value;
 		return Info;
 	}
 
-	FArticyPropertyInfo MakeProperty(const FString& LocaKey, const FString& Type)
+	// The importer fills both names: lookups go by technical name, the loca key is what
+	// gets handed to the string table. They are kept distinct here so a lookup that
+	// matched the wrong one would fail the test.
+	FArticyPropertyInfo MakeProperty(const FString& TechnicalName, const FString& Type)
 	{
 		FArticyPropertyInfo Info;
-		Info.LocaKey_DisplayName = LocaKey;
+		Info.TechnicalName = TechnicalName;
+		Info.LocaKey_DisplayName = TechnicalName + TEXT(".DisplayName");
 		Info.PropertyType = Type;
+		return Info;
+	}
+
+	FArticyPropertyInfo MakeFeatureProperty(const FString& Feature, const FString& TechnicalName, const FString& Type)
+	{
+		FArticyPropertyInfo Info = MakeProperty(Feature + TEXT(".") + TechnicalName, Type);
+		Info.IsTemplateProperty = true;
 		return Info;
 	}
 }
@@ -38,10 +51,10 @@ void FArticyTypeSpec::Define()
 		{
 			FArticyType Type;
 			Type.EnumValues = { MakeEnumValue(TEXT("Red"), 0), MakeEnumValue(TEXT("Green"), 1) };
-			TestEqual(TEXT("by value"), Type.GetEnumValue(1).LocaKey_DisplayName, FString(TEXT("Green")));
+			TestEqual(TEXT("by value"), Type.GetEnumValue(1).TechnicalName, FString(TEXT("Green")));
 		});
 
-		It("finds an enum value by its loca key", [this]()
+		It("finds an enum value by its technical name", [this]()
 		{
 			FArticyType Type;
 			Type.EnumValues = { MakeEnumValue(TEXT("Red"), 0), MakeEnumValue(TEXT("Green"), 1) };
@@ -52,17 +65,25 @@ void FArticyTypeSpec::Define()
 		{
 			FArticyType Type;
 			Type.EnumValues = { MakeEnumValue(TEXT("Red"), 0) };
-			TestEqual(TEXT("missing"), Type.GetEnumValue(99).LocaKey_DisplayName, FString());
+			TestEqual(TEXT("missing"), Type.GetEnumValue(99).TechnicalName, FString());
 		});
 	});
 
 	Describe("GetProperty", [this]()
 	{
-		It("finds a property by its loca key", [this]()
+		It("finds a property by its technical name", [this]()
 		{
 			FArticyType Type;
 			Type.Properties = { MakeProperty(TEXT("Speed"), TEXT("float")) };
 			TestEqual(TEXT("type"), Type.GetProperty(TEXT("Speed")).PropertyType, FString(TEXT("float")));
+		});
+
+		It("finds a feature property by its qualified name", [this]()
+		{
+			FArticyType Type;
+			Type.Properties = { MakeFeatureProperty(TEXT("Stats"), TEXT("Speed"), TEXT("float")) };
+			TestEqual(TEXT("qualified"), Type.GetProperty(TEXT("Stats.Speed")).PropertyType, FString(TEXT("float")));
+			TestTrue(TEXT("unqualified does not match"), Type.GetProperty(TEXT("Speed")).PropertyType.IsEmpty());
 		});
 
 		It("returns a default property when nothing matches", [this]()
@@ -101,10 +122,41 @@ void FArticyTypeSpec::Define()
 			TestEqual(TEXT("loca key"), Type.GetFeatureDisplayNameLocaKey(TEXT("Stats")), FString(TEXT("Stats")));
 		});
 
-		It("returns no properties for a feature (not yet implemented)", [this]()
+		It("returns the properties belonging to a feature", [this]()
 		{
 			FArticyType Type;
-			Type.Properties = { MakeProperty(TEXT("Speed"), TEXT("float")) };
+			Type.Features = { TEXT("Stats") };
+			Type.Properties = {
+				MakeProperty(TEXT("DisplayName"), TEXT("string")),
+				MakeFeatureProperty(TEXT("Stats"), TEXT("Speed"), TEXT("float")),
+				MakeFeatureProperty(TEXT("Stats"), TEXT("Health"), TEXT("int")),
+				MakeFeatureProperty(TEXT("Combat"), TEXT("Damage"), TEXT("int"))
+			};
+
+			const TArray<FArticyPropertyInfo> InFeature = Type.GetPropertiesInFeature(TEXT("Stats"));
+
+			TestEqual(TEXT("count"), InFeature.Num(), 2);
+			if (InFeature.Num() == 2)
+			{
+				// Names stay qualified, so they can be fed straight back into GetProperty.
+				TestEqual(TEXT("first"), InFeature[0].TechnicalName, FString(TEXT("Stats.Speed")));
+				TestEqual(TEXT("second"), InFeature[1].TechnicalName, FString(TEXT("Stats.Health")));
+			}
+		});
+
+		It("returns nothing for a feature that has no properties", [this]()
+		{
+			FArticyType Type;
+			Type.Properties = { MakeFeatureProperty(TEXT("Stats"), TEXT("Speed"), TEXT("float")) };
+			TestEqual(TEXT("empty"), Type.GetPropertiesInFeature(TEXT("Combat")).Num(), 0);
+		});
+
+		It("does not mistake a plain property for a feature property", [this]()
+		{
+			// A non-template property whose name happens to carry a dot must not be
+			// reported as living in a feature.
+			FArticyType Type;
+			Type.Properties = { MakeProperty(TEXT("Stats.Speed"), TEXT("float")) };
 			TestEqual(TEXT("empty"), Type.GetPropertiesInFeature(TEXT("Stats")).Num(), 0);
 		});
 	});

--- a/Source/ArticyTests/Private/Runtime/ArticyTypeSystemSpec.cpp
+++ b/Source/ArticyTests/Private/Runtime/ArticyTypeSystemSpec.cpp
@@ -1,0 +1,77 @@
+//
+// Copyright (c) 2026 articy Software GmbH & Co. KG. All rights reserved.
+//
+
+#include "Misc/AutomationTest.h"
+#include "ArticyTypeSystem.h"
+#include "UObject/StrongObjectPtr.h"
+
+#if WITH_AUTOMATION_TESTS
+
+namespace
+{
+	FArticyType MakeCharacterType()
+	{
+		FArticyPropertyInfo DisplayName;
+		DisplayName.TechnicalName = TEXT("DisplayName");
+		DisplayName.PropertyType = TEXT("string");
+
+		FArticyType Type;
+		Type.TechnicalName = TEXT("Character");
+		Type.CPPType = TEXT("UTestProjectCharacter");
+		Type.Properties = { DisplayName };
+		return Type;
+	}
+}
+
+BEGIN_DEFINE_SPEC(FArticyTypeSystemSpec, "Articy.Runtime.TypeSystem",
+	EAutomationTestFlags::EditorContext | EAutomationTestFlags::ProductFilter)
+END_DEFINE_SPEC(FArticyTypeSystemSpec)
+
+void FArticyTypeSystemSpec::Define()
+{
+	Describe("GetArticyType", [this]()
+	{
+		It("returns the metadata registered for a type name", [this]()
+		{
+			TStrongObjectPtr<UArticyTypeSystem> TypeSystem(NewObject<UArticyTypeSystem>());
+			TypeSystem->Types.Add(TEXT("Character"), MakeCharacterType());
+
+			const FArticyType Type = TypeSystem->GetArticyType(TEXT("Character"));
+			TestEqual(TEXT("technical name"), Type.TechnicalName, FString(TEXT("Character")));
+			TestEqual(TEXT("property type"), Type.GetProperty(TEXT("DisplayName")).PropertyType, FString(TEXT("string")));
+		});
+
+		It("returns a default type for an unknown type name", [this]()
+		{
+			TStrongObjectPtr<UArticyTypeSystem> TypeSystem(NewObject<UArticyTypeSystem>());
+			TypeSystem->Types.Add(TEXT("Character"), MakeCharacterType());
+
+			TestTrue(TEXT("unknown"), TypeSystem->GetArticyType(TEXT("Nope")).TechnicalName.IsEmpty());
+		});
+
+		It("returns a default type when nothing has been imported", [this]()
+		{
+			TStrongObjectPtr<UArticyTypeSystem> TypeSystem(NewObject<UArticyTypeSystem>());
+			TestTrue(TEXT("empty"), TypeSystem->GetArticyType(TEXT("Character")).TechnicalName.IsEmpty());
+		});
+	});
+
+	Describe("Get", [this]()
+	{
+		It("always returns a usable instance", [this]()
+		{
+			// Without an imported project there is no generated type system asset, so this
+			// falls back to an empty placeholder rather than returning null.
+			TestNotNull(TEXT("instance"), UArticyTypeSystem::Get());
+		});
+
+		It("returns the same instance while it is alive", [this]()
+		{
+			TStrongObjectPtr<UArticyTypeSystem> First(UArticyTypeSystem::Get());
+			TestTrue(TEXT("cached"), UArticyTypeSystem::Get() == First.Get());
+		});
+	});
+}
+
+#endif // WITH_AUTOMATION_TESTS

--- a/docs/articles/text_extensions.md
+++ b/docs/articles/text_extensions.md
@@ -66,6 +66,33 @@ When working with multiple instances of the same object, you can specify an **in
 ```
 This targets the 15th instance of the **Guard** object and retrieves the **HP** property.
 
+#### Property Types
+Instead of a value, a token can ask for the *type* of a property. `$Type` takes an articy type
+name and a property, and resolves to the type articy declared that property as (`string`,
+`int`, `bool`, an enum or template name, and so on).
+
+**Examples:**
+```text
+[$Type.Character.DisplayName]
+```
+Resolves to `string`, the type of the **DisplayName** property on the **Character** type.
+
+```text
+[$Type.Character.Basic.Backstory]
+```
+Properties that live in a feature are addressed the same way they are on an object: by their
+`<Feature>.<Property>` name.
+
+You can also ask an object what type one of its properties has, by appending `.$Type`:
+
+```text
+[Chr_Manfred.Character.Motivation.$Type]
+```
+
+Both forms need the type metadata that the importer generates, so they resolve only after the
+project has been imported. A token that names an unknown type or property is left as its own
+source text, the same fallback the other token sources use.
+
 ---
 
 ### Token Formatting

--- a/docs/articles/type_system.md
+++ b/docs/articles/type_system.md
@@ -102,6 +102,21 @@ for (const FArticyPropertyInfo& Attr : Attributes)
 ```
 In this example, we access all properties in the "Attributes" feature of the `Character` type.
 
+A feature's properties are part of the type they belong to, listed under their qualified
+`<Feature>.<Property>` technical name. That is the same name a text-extension token uses, so
+`GetProperty()` and `GetPropertiesInFeature()` both work with it:
+
+```cpp
+FArticyType CharacterType = UArticyTypeSystem::Get()->GetArticyType("Character");
+
+// Both of these describe the same property
+FArticyPropertyInfo Speed = CharacterType.GetProperty("Attributes.Speed");
+FArticyPropertyInfo Same  = CharacterType.GetPropertiesInFeature("Attributes")[0];
+```
+
+`Features` lists the technical names of a type's features, so an entry can be passed straight
+into `GetPropertiesInFeature()`.
+
 ---
 
 ### Enums in the Type System


### PR DESCRIPTION
Fix articy type metadata not being populated at runtime:

- Token detection was unreachable
- The runtime type map was never loaded
- Property metadata was half-filled and looked up inconsistently
- `GetArticyType()` returned an empty type

Also implements GetPropertiesInFeature(), previously a return {} stub.